### PR TITLE
qbt version command

### DIFF
--- a/qbt-manifest
+++ b/qbt-manifest
@@ -2122,7 +2122,7 @@
                 }
             }
         },
-        "version": "32306d35330081f67c6046d4b60a3014cc7ce01a"
+        "version": "dcae72d1d9ea3918cf89c60b13b5e6be7d805a28"
     },
     "wrapper_generator": {
         "packages": {

--- a/qbt-manifest
+++ b/qbt-manifest
@@ -1961,7 +1961,7 @@
                 }
             }
         },
-        "version": "6910d6bb624247e6be517cfa78653e7950572418"
+        "version": "44f1bfc23c31f3a1239b86da32af6ce0ddbf28ec"
     },
     "pbt": {
         "packages": {

--- a/qbt-manifest
+++ b/qbt-manifest
@@ -1961,7 +1961,7 @@
                 }
             }
         },
-        "version": "2c60d4e35fb1266d075fe44c54eb80cbda661677"
+        "version": "e87e9a70232b2c4eb12e8f709b9cb87eaa63744d"
     },
     "pbt": {
         "packages": {

--- a/qbt-manifest
+++ b/qbt-manifest
@@ -1961,7 +1961,7 @@
                 }
             }
         },
-        "version": "2f0f3fce03512633afcf4ad230fd86b18be32518"
+        "version": "c778fe28154df7a2c35df6a1811e9758940f8ffa"
     },
     "pbt": {
         "packages": {

--- a/qbt-manifest
+++ b/qbt-manifest
@@ -2135,6 +2135,8 @@
                     }
                 },
                 "normalDeps": {
+                    "mc.com.google.code.gson.gson": "Strong,HEAD",
+                    "mc.com.google.guava.guava": "Strong,HEAD",
                     "misc1.java_build_process": "Weak,HEAD"
                 },
                 "verifyDeps": {
@@ -2167,6 +2169,6 @@
                 }
             }
         },
-        "version": "1134f9e3fa5e8914503d60e4d32e6f04dce82042"
+        "version": "1b9181351601363dc22b7c4f22c4d4ceda48bbf5"
     }
 }

--- a/qbt-manifest
+++ b/qbt-manifest
@@ -1698,7 +1698,7 @@
                 }
             }
         },
-        "version": "b14df1c754669459e4800fea01972aef4c684681"
+        "version": "68401b6b26085daaa0895530bab47fe7e4f30a89"
     },
     "misc1": {
         "packages": {

--- a/qbt-manifest
+++ b/qbt-manifest
@@ -2169,6 +2169,6 @@
                 }
             }
         },
-        "version": "1b9181351601363dc22b7c4f22c4d4ceda48bbf5"
+        "version": "c7d0bfe1ceced19121e441d82f2e16e83f7d3632"
     }
 }

--- a/qbt-manifest
+++ b/qbt-manifest
@@ -1961,7 +1961,7 @@
                 }
             }
         },
-        "version": "44f1bfc23c31f3a1239b86da32af6ce0ddbf28ec"
+        "version": "2f0f3fce03512633afcf4ad230fd86b18be32518"
     },
     "pbt": {
         "packages": {
@@ -2122,7 +2122,7 @@
                 }
             }
         },
-        "version": "dcae72d1d9ea3918cf89c60b13b5e6be7d805a28"
+        "version": "7de4b3647d742fc3834a0035f3e63c224d22813a"
     },
     "wrapper_generator": {
         "packages": {

--- a/qbt-manifest
+++ b/qbt-manifest
@@ -1961,7 +1961,7 @@
                 }
             }
         },
-        "version": "e87e9a70232b2c4eb12e8f709b9cb87eaa63744d"
+        "version": "6910d6bb624247e6be517cfa78653e7950572418"
     },
     "pbt": {
         "packages": {

--- a/qbt-manifest
+++ b/qbt-manifest
@@ -2123,7 +2123,7 @@
                 }
             }
         },
-        "version": "7de4b3647d742fc3834a0035f3e63c224d22813a"
+        "version": "4e257aab80a080cde447d5c5958b74a881a9b8a0"
     },
     "wrapper_generator": {
         "packages": {

--- a/qbt-manifest
+++ b/qbt-manifest
@@ -1689,7 +1689,8 @@
                     "archIndependent": true,
                     "prefix": "release",
                     "qbtEnv": {
-                        "JDK": "1_8"
+                        "JDK": "1_8",
+                        "VANITY_NAME": null
                     }
                 },
                 "normalDeps": {


### PR DESCRIPTION
One can now print the CV of meta_tools and qbt.app.main by invoking 'qbt
version'.  There is also infrastructure to easily add version information for
other applications based upon qbt.bin.

Resolves TerabyteQbt/meta#6
Parallel to PR AmlingQbt/meta#8